### PR TITLE
:tada: redisTemplate을 사용하기 위한 의존성 설정 및 Config 등록

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,8 @@ dependencies {
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
+    // jackson이 LocalTime을 지원할수 있게 하는 의존성 추가
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 }
 
 tasks.named('test') {

--- a/src/main/java/sipozizo/tabling/common/config/RedisConfig.java
+++ b/src/main/java/sipozizo/tabling/common/config/RedisConfig.java
@@ -1,0 +1,47 @@
+package sipozizo.tabling.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import sipozizo.tabling.common.entity.Store;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        return template;
+    }
+
+    @Bean
+    public RedisTemplate<String, Store> storeRedisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Store> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        return template;
+    }
+
+    @Bean
+    public RedisTemplate<String, Integer> countRedisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Integer> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        return template;
+    }
+
+}

--- a/src/main/java/sipozizo/tabling/domain/store/model/response/StoreWithViewCountResponseV1.java
+++ b/src/main/java/sipozizo/tabling/domain/store/model/response/StoreWithViewCountResponseV1.java
@@ -1,0 +1,19 @@
+package sipozizo.tabling.domain.store.model.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import sipozizo.tabling.common.entity.Store;
+
+@Getter
+@AllArgsConstructor
+public class StoreWithViewCountResponseV1 {
+
+    private Long id;
+    private String storeName;
+    private String storeNumber;
+    private Integer viewCount;
+
+    public static StoreWithViewCountResponseV1 of(Store store) {
+        return new StoreWithViewCountResponseV1(store.getId(), store.getStoreName(), store.getStoreNumber(), store.getView());
+    }
+}


### PR DESCRIPTION
## 목적
- RedisTemplate를 사용하기 위한 초기 설정

## 변경 사항
- build.gradle 파일에서 jackson이 LocalTime을 지원할수 있게 하는 의존성 추가
- redisTemplate를 사용하기 위해 config 파일 추가

## To Reviewer
